### PR TITLE
Add collectionobject brief description field to Elasticsearch full text index

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -105,6 +105,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/athenaeum/athenaeum-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/athenaeum/athenaeum-tenant-bindings.delta.xml
@@ -96,6 +96,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/averylibrary/averylibrary-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/averylibrary/averylibrary-tenant-bindings.delta.xml
@@ -578,6 +578,10 @@
                       }
                     }
                   },
+                  "collectionobjects_common:briefDescriptions": {
+                    "type": "text",
+                    "copy_to": "all_field"
+                  },
                   "collectionobjects_common:materialGroupList": {
                     "type": "object",
                     "properties": {

--- a/services/common/src/main/cspace/config/services/tenants/csws/csws-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/csws/csws-tenant-bindings.delta.xml
@@ -105,6 +105,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -96,6 +96,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/fwm/fwm-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fwm/fwm-tenant-bindings.delta.xml
@@ -96,6 +96,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/gsd/gsd-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/gsd/gsd-tenant-bindings.delta.xml
@@ -578,6 +578,10 @@
                       }
                     }
                   },
+                  "collectionobjects_common:briefDescriptions": {
+                    "type": "text",
+                    "copy_to": "all_field"
+                  },
                   "collectionobjects_common:materialGroupList": {
                     "type": "object",
                     "properties": {

--- a/services/common/src/main/cspace/config/services/tenants/materialorder/materialorder-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/materialorder/materialorder-tenant-bindings.delta.xml
@@ -578,6 +578,10 @@
                       }
                     }
                   },
+                  "collectionobjects_common:briefDescriptions": {
+                    "type": "text",
+                    "copy_to": "all_field"
+                  },
                   "collectionobjects_common:materialGroupList": {
                     "type": "object",
                     "properties": {

--- a/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
@@ -578,6 +578,10 @@
                       }
                     }
                   },
+                  "collectionobjects_common:briefDescriptions": {
+                    "type": "text",
+                    "copy_to": "all_field"
+                  },
                   "collectionobjects_common:materialGroupList": {
                     "type": "object",
                     "properties": {

--- a/services/common/src/main/cspace/config/services/tenants/mcgill/mcgill-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/mcgill/mcgill-tenant-bindings.delta.xml
@@ -96,6 +96,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/ohc/ohc-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/ohc/ohc-tenant-bindings.delta.xml
@@ -105,6 +105,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/parsons/parsons-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/parsons/parsons-tenant-bindings.delta.xml
@@ -578,6 +578,10 @@
                       }
                     }
                   },
+                  "collectionobjects_common:briefDescriptions": {
+                    "type": "text",
+                    "copy_to": "all_field"
+                  },
                   "collectionobjects_common:materialGroupList": {
                     "type": "object",
                     "properties": {

--- a/services/common/src/main/cspace/config/services/tenants/risd/risd-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/risd/risd-tenant-bindings.delta.xml
@@ -578,6 +578,10 @@
                       }
                     }
                   },
+                  "collectionobjects_common:briefDescriptions": {
+                    "type": "text",
+                    "copy_to": "all_field"
+                  },
                   "collectionobjects_common:materialGroupList": {
                     "type": "object",
                     "properties": {

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1082,6 +1082,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {

--- a/services/common/src/main/cspace/config/services/tenants/thenvm/thenvm-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/thenvm/thenvm-tenant-bindings.delta.xml
@@ -96,6 +96,10 @@
 							"type": "keyword",
 							"copy_to": "all_field"
 						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
 						"collectionobjects_common:titleGroupList": {
 							"type": "object",
 							"properties": {


### PR DESCRIPTION
Fix for: https://lyrasis.zendesk.com/agent/tickets/9486

This updates tenant configs to make `collectionobjects_common:briefDescriptions` full text searchable in the public browser. (Only Breman is complaining about this, but this pre-emptively updates all tenants).