### PR TITLE
DRYD-982: Add featured collection and named collection to materials es index.

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/materials/materials-tenant-bindings.delta.xml
@@ -30,6 +30,7 @@
                     "ecm:name",
                     "ecm:primaryType",
                     "materials_common:shortIdentifier",
+                    "materials_common:featuredCollectionGroupList",
                     "materials_common:publishToList",
                     "materials_common:externalUrlGroupList",
                     "materials_common:materialTermGroupList",
@@ -78,6 +79,7 @@
                     "collectionobjects_common:otherNumberList",
                     "collectionobjects_common:ownersContributionNote",
                     "collectionobjects_common:collection",
+                    "collectionobjects_common:namedCollections",
                     "collectionobjects_common:computedCurrentLocation",
                     "collectionobjects_materials:materialContainerGroupList",
                     "collectionobjects_materials:materialConditionGroupList",
@@ -171,6 +173,15 @@
                     "properties": {
                       "termDisplayName": {
                         "type": "text",
+                        "copy_to": "all_field"
+                      }
+                    }
+                  },
+                  "materials_common:featuredCollectionGroupList": {
+                    "type": "object",
+                    "properties": {
+                      "featuredCollection": {
+                        "type": "keyword",
                         "copy_to": "all_field"
                       }
                     }


### PR DESCRIPTION
This makes featured collection (material authority record) and named collection (object record) available to the materials profile public browser.