### PR TITLE
DRYD-982: Update materials-based tenant configs.

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/averylibrary/averylibrary-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/averylibrary/averylibrary-tenant-bindings.delta.xml
@@ -30,6 +30,7 @@
                     "ecm:name",
                     "ecm:primaryType",
                     "materials_common:shortIdentifier",
+                    "materials_common:featuredCollectionGroupList",
                     "materials_common:publishToList",
                     "materials_common:externalUrlGroupList",
                     "materials_common:materialTermGroupList",
@@ -78,6 +79,7 @@
                     "collectionobjects_common:otherNumberList",
                     "collectionobjects_common:ownersContributionNote",
                     "collectionobjects_common:collection",
+                    "collectionobjects_common:namedCollections",
                     "collectionobjects_common:computedCurrentLocation",
                     "collectionobjects_materials:materialContainerGroupList",
                     "collectionobjects_materials:materialConditionGroupList",
@@ -171,6 +173,15 @@
                     "properties": {
                       "termDisplayName": {
                         "type": "text",
+                        "copy_to": "all_field"
+                      }
+                    }
+                  },
+                  "materials_common:featuredCollectionGroupList": {
+                    "type": "object",
+                    "properties": {
+                      "featuredCollection": {
+                        "type": "keyword",
                         "copy_to": "all_field"
                       }
                     }

--- a/services/common/src/main/cspace/config/services/tenants/gsd/gsd-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/gsd/gsd-tenant-bindings.delta.xml
@@ -30,6 +30,7 @@
                     "ecm:name",
                     "ecm:primaryType",
                     "materials_common:shortIdentifier",
+                    "materials_common:featuredCollectionGroupList",
                     "materials_common:publishToList",
                     "materials_common:externalUrlGroupList",
                     "materials_common:materialTermGroupList",
@@ -78,6 +79,7 @@
                     "collectionobjects_common:otherNumberList",
                     "collectionobjects_common:ownersContributionNote",
                     "collectionobjects_common:collection",
+                    "collectionobjects_common:namedCollections",
                     "collectionobjects_common:computedCurrentLocation",
                     "collectionobjects_materials:materialContainerGroupList",
                     "collectionobjects_materials:materialConditionGroupList",
@@ -171,6 +173,15 @@
                     "properties": {
                       "termDisplayName": {
                         "type": "text",
+                        "copy_to": "all_field"
+                      }
+                    }
+                  },
+                  "materials_common:featuredCollectionGroupList": {
+                    "type": "object",
+                    "properties": {
+                      "featuredCollection": {
+                        "type": "keyword",
                         "copy_to": "all_field"
                       }
                     }

--- a/services/common/src/main/cspace/config/services/tenants/materialorder/materialorder-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/materialorder/materialorder-tenant-bindings.delta.xml
@@ -30,6 +30,7 @@
                     "ecm:name",
                     "ecm:primaryType",
                     "materials_common:shortIdentifier",
+                    "materials_common:featuredCollectionGroupList",
                     "materials_common:publishToList",
                     "materials_common:externalUrlGroupList",
                     "materials_common:materialTermGroupList",
@@ -78,6 +79,7 @@
                     "collectionobjects_common:otherNumberList",
                     "collectionobjects_common:ownersContributionNote",
                     "collectionobjects_common:collection",
+                    "collectionobjects_common:namedCollections",
                     "collectionobjects_common:computedCurrentLocation",
                     "collectionobjects_materials:materialContainerGroupList",
                     "collectionobjects_materials:materialConditionGroupList",
@@ -171,6 +173,15 @@
                     "properties": {
                       "termDisplayName": {
                         "type": "text",
+                        "copy_to": "all_field"
+                      }
+                    }
+                  },
+                  "materials_common:featuredCollectionGroupList": {
+                    "type": "object",
+                    "properties": {
+                      "featuredCollection": {
+                        "type": "keyword",
                         "copy_to": "all_field"
                       }
                     }

--- a/services/common/src/main/cspace/config/services/tenants/parsons/parsons-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/parsons/parsons-tenant-bindings.delta.xml
@@ -30,6 +30,7 @@
                     "ecm:name",
                     "ecm:primaryType",
                     "materials_common:shortIdentifier",
+                    "materials_common:featuredCollectionGroupList",
                     "materials_common:publishToList",
                     "materials_common:externalUrlGroupList",
                     "materials_common:materialTermGroupList",
@@ -78,6 +79,7 @@
                     "collectionobjects_common:otherNumberList",
                     "collectionobjects_common:ownersContributionNote",
                     "collectionobjects_common:collection",
+                    "collectionobjects_common:namedCollections",
                     "collectionobjects_common:computedCurrentLocation",
                     "collectionobjects_materials:materialContainerGroupList",
                     "collectionobjects_materials:materialConditionGroupList",
@@ -171,6 +173,15 @@
                     "properties": {
                       "termDisplayName": {
                         "type": "text",
+                        "copy_to": "all_field"
+                      }
+                    }
+                  },
+                  "materials_common:featuredCollectionGroupList": {
+                    "type": "object",
+                    "properties": {
+                      "featuredCollection": {
+                        "type": "keyword",
                         "copy_to": "all_field"
                       }
                     }

--- a/services/common/src/main/cspace/config/services/tenants/risd/risd-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/risd/risd-tenant-bindings.delta.xml
@@ -30,6 +30,7 @@
                     "ecm:name",
                     "ecm:primaryType",
                     "materials_common:shortIdentifier",
+                    "materials_common:featuredCollectionGroupList",
                     "materials_common:publishToList",
                     "materials_common:externalUrlGroupList",
                     "materials_common:materialTermGroupList",
@@ -78,6 +79,7 @@
                     "collectionobjects_common:otherNumberList",
                     "collectionobjects_common:ownersContributionNote",
                     "collectionobjects_common:collection",
+                    "collectionobjects_common:namedCollections",
                     "collectionobjects_common:computedCurrentLocation",
                     "collectionobjects_materials:materialContainerGroupList",
                     "collectionobjects_materials:materialConditionGroupList",
@@ -171,6 +173,15 @@
                     "properties": {
                       "termDisplayName": {
                         "type": "text",
+                        "copy_to": "all_field"
+                      }
+                    }
+                  },
+                  "materials_common:featuredCollectionGroupList": {
+                    "type": "object",
+                    "properties": {
+                      "featuredCollection": {
+                        "type": "keyword",
                         "copy_to": "all_field"
                       }
                     }


### PR DESCRIPTION
I updated the materials tenant config in #10, but forgot to also apply the changes to the configs of all the tenants that are based on materials.

This means the materials tenants need to be redeployed and elasticsearch reindexed, sorry!