### PR TITLE
DRYD-1231: Replace nuxeo maven repos with ours.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,17 +62,35 @@
 			</snapshots>
 		</repository>
 
-		<repository>
+		<!-- <repository>
 			<id>nuxeo-public-releases</id>
 			<url>http://maven-eu.nuxeo.org/nexus/content/repositories/public-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
-		</repository>
+		</repository> -->
 
-		<repository>
+		<!-- <repository>
 			<id>nuxeo-vendor-releases</id>
 			<url>http://maven-eu.nuxeo.org/nexus/content/repositories/vendor-releases</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository> -->
+
+		<!-- CSpace copy of nuxeo-public-releases repo. -->
+		<repository>
+			<id>cspace-nuxeo-public-releases</id>
+			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/public-releases</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+
+		<!-- CSpace copy of nuxeo-vendor-releases repo. -->
+		<repository>
+			<id>cspace-nuxeo-vendor-releases</id>
+			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/nuxeo/vendor-releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
This replaces nuxeo maven repos with cspace (s3-hosted) repos. The artifacts that were being downloaded from the nuxeo repos have been copied to the cspace repos, so the nuxeo ones are no longer needed. This resolves build failures that occur when the nuxeo repos are down.