### PR TITLE
ElasticSearch indexing fixes

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/DefaultESDocumentWriter.java
@@ -212,7 +212,10 @@ private void denormExhibitionRecords(CoreSession session, String csid, String te
 
 		if (objectNameGroups.size() > 0) {
 			Map<String, Object> primaryObjectNameGroup = objectNameGroups.get(0);
-			primaryObjectName = (String) primaryObjectNameGroup.get("objectName");
+			primaryObjectName = (String) primaryObjectNameGroup.get("objectNameControlled");
+			if (primaryObjectName == null) {
+				primaryObjectName = (String) primaryObjectNameGroup.get("objectName");
+			}
 
 			// The object might be a refname in some profiles/tenants. If it is, use only the display name.
 

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -132,6 +132,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -31,6 +31,7 @@
 							"collectionobjects_common:contentConcepts",
 							"collectionobjects_common:fieldCollectionDateGroup",
 							"collectionobjects_common:fieldCollectors",
+							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -234,6 +235,15 @@
 											"normalizer": "refname_displayname_normalizer"
 										}
 									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -31,7 +31,6 @@
 							"collectionobjects_common:contentConcepts",
 							"collectionobjects_common:fieldCollectionDateGroup",
 							"collectionobjects_common:fieldCollectors",
-							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -120,6 +119,15 @@
 								},
 								"curatorialNote": {
 									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
 									"copy_to": "all_field"
 								}
 							}
@@ -217,15 +225,6 @@
 											"normalizer": "refname_displayname_normalizer"
 										}
 									}
-								}
-							}
-						},
-						"collectionobjects_common:materialGroupList": {
-							"type": "object",
-							"properties": {
-								"material": {
-									"type": "keyword",
-									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/anthro/anthro-tenant-bindings.delta.xml
@@ -210,7 +210,13 @@
 							"properties": {
 								"objectProductionPlace": {
 									"type": "keyword",
-									"copy_to": "all_field"
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/athenaeum/athenaeum-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/athenaeum/athenaeum-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
@@ -1,14 +1,284 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-        xmlns:merge='http://xmlmerge.el4j.elca.ch'
-        xmlns:tenant='http://collectionspace.org/services/config/tenant'>
+	xmlns:merge='http://xmlmerge.el4j.elca.ch'
+	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/bonsai-tenant-bindings-proto.xml -->
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/bonsai-tenant-bindings-proto.xml -->
 
-    <tenant:tenantBinding id="3000">
-    </tenant:tenantBinding>
+	<tenant:tenantBinding id="3000">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
+
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+
+	</tenant:tenantBinding>
 
 </tenant:TenantBindingConfig>
 

--- a/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bonsai/bonsai-tenant-bindings.delta.xml
@@ -25,6 +25,7 @@
 							"collectionobjects_common:colors",
 							"collectionobjects_common:computedCurrentLocation",
 							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -221,6 +222,15 @@
 								}
 							}
 						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 						"collectionobjects_common:colors": {
 							"type": "keyword",
 							"copy_to": "all_field"
@@ -281,4 +291,3 @@
 	</tenant:tenantBinding>
 
 </tenant:TenantBindingConfig>
-

--- a/services/common/src/main/cspace/config/services/tenants/bplarts/bplarts-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/bplarts/bplarts-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/catholicu/catholicu-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/catholicu/catholicu-tenant-bindings.delta.xml
@@ -124,6 +124,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",
@@ -210,7 +228,13 @@
 							"properties": {
 								"objectProductionPlace": {
 									"type": "keyword",
-									"copy_to": "all_field"
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/ccp/ccp-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/ccp/ccp-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -25,7 +25,6 @@
 							"collectionobjects_common:colors",
 							"collectionobjects_common:computedCurrentLocation",
 							"collectionobjects_common:contentConcepts",
-							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -111,6 +110,15 @@
 								},
 								"curatorialNote": {
 									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
 									"copy_to": "all_field"
 								}
 							}
@@ -202,15 +210,6 @@
 											"normalizer": "refname_displayname_normalizer"
 										}
 									}
-								}
-							}
-						},
-						"collectionobjects_common:materialGroupList": {
-							"type": "object",
-							"properties": {
-								"material": {
-									"type": "keyword",
-									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -123,6 +123,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fcart/fcart-tenant-bindings.delta.xml
@@ -25,6 +25,7 @@
 							"collectionobjects_common:colors",
 							"collectionobjects_common:computedCurrentLocation",
 							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -219,6 +220,15 @@
 											"normalizer": "refname_displayname_normalizer"
 										}
 									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/fwm/fwm-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/fwm/fwm-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/hku/hku-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/hku/hku-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/mcgill/mcgill-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/mcgill/mcgill-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/mnarb/mnarb-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/mnarb/mnarb-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/momm/momm-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/momm/momm-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/ohc/ohc-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/ohc/ohc-tenant-bindings.delta.xml
@@ -124,6 +124,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/pbm/pbm-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/pbm/pbm-tenant-bindings.delta.xml
@@ -1,13 +1,293 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-        xmlns:merge='http://xmlmerge.el4j.elca.ch'
-        xmlns:tenant='http://collectionspace.org/services/config/tenant'>
+	xmlns:merge='http://xmlmerge.el4j.elca.ch'
+	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/bonsai-tenant-bindings-proto.xml -->
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/bonsai-tenant-bindings-proto.xml -->
 
-    <tenant:tenantBinding id="100004">
-    </tenant:tenantBinding>
+	<tenant:tenantBinding id="100004">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:materialGroupList",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
+
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+
+	</tenant:tenantBinding>
 
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/peabody/peabody-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/peabody/peabody-tenant-bindings.delta.xml
@@ -124,6 +124,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",
@@ -210,7 +228,13 @@
 							"properties": {
 								"objectProductionPlace": {
 									"type": "keyword",
-									"copy_to": "all_field"
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
 								}
 							}
 						},

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1228,6 +1228,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1131,6 +1131,7 @@
 							"collectionobjects_common:colors",
 							"collectionobjects_common:computedCurrentLocation",
 							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -1316,6 +1317,15 @@
 							"type": "object",
 							"properties": {
 								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
 									"type": "keyword",
 									"copy_to": "all_field"
 								}

--- a/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
+++ b/services/common/src/main/cspace/config/services/tenants/tenant-bindings-proto-unified.xml
@@ -1131,7 +1131,6 @@
 							"collectionobjects_common:colors",
 							"collectionobjects_common:computedCurrentLocation",
 							"collectionobjects_common:contentConcepts",
-							"collectionobjects_common:materialGroupList",
 							"collectionobjects_common:measuredPartGroupList",
 							"collectionobjects_common:numberOfObjects",
 							"collectionobjects_common:objectHistoryNote",
@@ -1220,6 +1219,15 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",
@@ -1299,15 +1307,6 @@
 							"type": "object",
 							"properties": {
 								"objectProductionPlace": {
-									"type": "keyword",
-									"copy_to": "all_field"
-								}
-							}
-						},
-						"collectionobjects_common:materialGroupList": {
-							"type": "object",
-							"properties": {
-								"material": {
 									"type": "keyword",
 									"copy_to": "all_field"
 								}

--- a/services/common/src/main/cspace/config/services/tenants/thenvm/thenvm-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/thenvm/thenvm-tenant-bindings.delta.xml
@@ -115,6 +115,24 @@
 								}
 							}
 						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
 
 						"collectionobjects_common:objectNumber": {
 							"type": "keyword",


### PR DESCRIPTION
This fixes some issues with ElasticSearch indexing in 7.2. These changes will be included in CSpace 8.0, but we'd like to update the hosted instances before 8.0 is released.

The following issues are fixed:
- https://collectionspace.atlassian.net/browse/CB-18 (and subtasks)
- https://collectionspace.atlassian.net/browse/CB-22

This PR includes changes to the Java class that writes the ES index, as well as configuration updates to the anthro, bonsai, and fcart tenants. The changes to the anthro, bonsai, and fcart configurations are also applied to all DTS tenants based on those profiles.
