### PR TITLE
CB-20: Use controlled object name in computed title for anthro.

### DIFF
--- a/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/anthro/AnthroESDocumentWriter.java
+++ b/3rdparty/nuxeo/nuxeo-platform-elasticsearch/src/main/java/org/collectionspace/services/nuxeo/elasticsearch/anthro/AnthroESDocumentWriter.java
@@ -34,7 +34,23 @@ public class AnthroESDocumentWriter extends DefaultESDocumentWriter {
 
 		if (objectNameGroups.size() > 0) {
 			Map<String, Object> primaryObjectNameGroup = objectNameGroups.get(0);
-			primaryObjectName = (String) primaryObjectNameGroup.get("objectName");
+
+			primaryObjectName = (String) primaryObjectNameGroup.get("objectNameControlled");
+
+			if (primaryObjectName == null) {
+				primaryObjectName = (String) primaryObjectNameGroup.get("objectName");
+			}
+
+			// The object might be a refname. If it is, use only the display name.
+
+			try {
+				String displayName = RefNameUtils.getDisplayName(primaryObjectName);
+
+				if (displayName != null) {
+					primaryObjectName = displayName;
+				}
+			}
+			catch (Exception e) {}
 		}
 
 		if (StringUtils.isNotEmpty(primaryObjectName)) {


### PR DESCRIPTION
This is another ES indexing fix that should have been part of #14. It includes the controlled object name in the computed title field that is indexed in ElasticSearch, for the anthro profile. This fix will be included in the 8.0 release, but we'd like to get it in the DTS 7.2 release, along with the commits in #14.

This completes the fix for https://collectionspace.atlassian.net/browse/CB-20.