### PR TITLE
Update ES config in LHMC and LHMC-based tenants.

### DIFF
--- a/services/common/src/main/cspace/config/services/tenants/breman/breman-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/breman/breman-tenant-bindings.delta.xml
@@ -1,13 +1,342 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-	xmlns:merge='http://xmlmerge.el4j.elca.ch'
-	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
+		xmlns:merge='http://xmlmerge.el4j.elca.ch'
+		xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
 
-    <tenant:tenantBinding id="100011">
-    </tenant:tenantBinding>
+	<tenant:tenantBinding id="100011">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:contentDescription",
+							"collectionobjects_common:contentEvents",
+							"collectionobjects_common:contentOrganizations",
+							"collectionobjects_common:contentPersons",
+							"collectionobjects_common:materialGroupList",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:rightsGroupList.rightStatement",
+							"collectionobjects_common:rightsGroupList.standardizedRightStatement",
+							"collectionobjects_common:rightsInGroupList.rightReproductionStatement",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
 
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentDescription": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentEvents": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentOrganizations": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentPersons": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+	</tenant:tenantBinding>
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/kennesaw/kennesaw-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/kennesaw/kennesaw-tenant-bindings.delta.xml
@@ -1,13 +1,342 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-	xmlns:merge='http://xmlmerge.el4j.elca.ch'
-	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
-    
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
+		xmlns:merge='http://xmlmerge.el4j.elca.ch'
+		xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <tenant:tenantBinding id="100031">
-    </tenant:tenantBinding>
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
 
+	<tenant:tenantBinding id="100031">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:contentDescription",
+							"collectionobjects_common:contentEvents",
+							"collectionobjects_common:contentOrganizations",
+							"collectionobjects_common:contentPersons",
+							"collectionobjects_common:materialGroupList",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:rightsGroupList.rightStatement",
+							"collectionobjects_common:rightsGroupList.standardizedRightStatement",
+							"collectionobjects_common:rightsInGroupList.rightReproductionStatement",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
+
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentDescription": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentEvents": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentOrganizations": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentPersons": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+	</tenant:tenantBinding>
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/lhmc/lhmc-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/lhmc/lhmc-tenant-bindings.delta.xml
@@ -1,13 +1,342 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-	xmlns:merge='http://xmlmerge.el4j.elca.ch'
-	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
-    
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
+		xmlns:merge='http://xmlmerge.el4j.elca.ch'
+		xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <tenant:tenantBinding id="501">
-    </tenant:tenantBinding>
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
 
+	<tenant:tenantBinding id="501">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:contentDescription",
+							"collectionobjects_common:contentEvents",
+							"collectionobjects_common:contentOrganizations",
+							"collectionobjects_common:contentPersons",
+							"collectionobjects_common:materialGroupList",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:rightsGroupList.rightStatement",
+							"collectionobjects_common:rightsGroupList.standardizedRightStatement",
+							"collectionobjects_common:rightsInGroupList.rightReproductionStatement",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
+
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentDescription": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentEvents": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentOrganizations": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentPersons": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+	</tenant:tenantBinding>
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/usopc/usopc-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/usopc/usopc-tenant-bindings.delta.xml
@@ -1,13 +1,342 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-	xmlns:merge='http://xmlmerge.el4j.elca.ch'
-	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
-    
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
+		xmlns:merge='http://xmlmerge.el4j.elca.ch'
+		xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <tenant:tenantBinding id="100032">
-    </tenant:tenantBinding>
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
 
+	<tenant:tenantBinding id="100032">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:contentDescription",
+							"collectionobjects_common:contentEvents",
+							"collectionobjects_common:contentOrganizations",
+							"collectionobjects_common:contentPersons",
+							"collectionobjects_common:materialGroupList",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:rightsGroupList.rightStatement",
+							"collectionobjects_common:rightsGroupList.standardizedRightStatement",
+							"collectionobjects_common:rightsInGroupList.rightReproductionStatement",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
+
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentDescription": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentEvents": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentOrganizations": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentPersons": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+	</tenant:tenantBinding>
 </tenant:TenantBindingConfig>

--- a/services/common/src/main/cspace/config/services/tenants/westerville/westerville-tenant-bindings.delta.xml
+++ b/services/common/src/main/cspace/config/services/tenants/westerville/westerville-tenant-bindings.delta.xml
@@ -1,13 +1,342 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tenant:TenantBindingConfig
-	xmlns:merge='http://xmlmerge.el4j.elca.ch'
-	xmlns:tenant='http://collectionspace.org/services/config/tenant'>
-    
-    <!-- Add your changes, if any, within the following tag pair. -->
-    <!-- The value of the 'id' attribute, below, should match the corresponding -->
-    <!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
+		xmlns:merge='http://xmlmerge.el4j.elca.ch'
+		xmlns:tenant='http://collectionspace.org/services/config/tenant'>
 
-    <tenant:tenantBinding id="100033">
-    </tenant:tenantBinding>
+	<!-- Add your changes, if any, within the following tag pair. -->
+	<!-- The value of the 'id' attribute, below, should match the corresponding -->
+	<!-- value in cspace/config/services/tenants/lhmc-tenant-bindings-proto.xml -->
 
+	<tenant:tenantBinding id="100033">
+		<tenant:elasticSearchIndexConfig merge:action="replace">
+			<tenant:mapping merge:action="replace">
+				{
+					// For now, don't index a field unless there's a mapping explicitly defined. This keeps the
+					// index as small as possible. We may want to turn this on in the future, to support arbitrary
+					// searches through Elasticsearch, e.g. NXQL queries for ad hoc reporting in the CSpace UI.
+					"dynamic": false,
+					"_all" : {
+						"enabled": false
+					},
+					"_source": {
+						"includes": [
+							"collectionobjects_common:briefDescriptions",
+							"collectionobjects_common:collection",
+							"collectionobjects_common:colors",
+							"collectionobjects_common:computedCurrentLocation",
+							"collectionobjects_common:contentConcepts",
+							"collectionobjects_common:contentDescription",
+							"collectionobjects_common:contentEvents",
+							"collectionobjects_common:contentOrganizations",
+							"collectionobjects_common:contentPersons",
+							"collectionobjects_common:materialGroupList",
+							"collectionobjects_common:measuredPartGroupList",
+							"collectionobjects_common:numberOfObjects",
+							"collectionobjects_common:objectCountGroupList",
+							"collectionobjects_common:objectHistoryNote",
+							"collectionobjects_common:objectNameList",
+							"collectionobjects_common:objectNumber",
+							"collectionobjects_common:objectProductionDateGroupList",
+							"collectionobjects_common:objectProductionOrganizationGroupList",
+							"collectionobjects_common:objectProductionPersonGroupList",
+							"collectionobjects_common:objectProductionPeopleGroupList",
+							"collectionobjects_common:objectProductionPlaceGroupList",
+							"collectionobjects_common:objectStatusList",
+							"collectionobjects_common:otherNumberList",
+							"collectionobjects_common:ownersContributionNote",
+							"collectionobjects_common:publishToList",
+							"collectionobjects_common:responsibleDepartments",
+							"collectionobjects_common:rightsGroupList.rightStatement",
+							"collectionobjects_common:rightsGroupList.standardizedRightStatement",
+							"collectionobjects_common:rightsInGroupList.rightReproductionStatement",
+							"collectionobjects_common:techniqueGroupList",
+							"collectionobjects_common:titleGroupList",
+							"collectionobjects_common:viewersContributionNote",
+							"collectionspace_core:*",
+							"collectionspace_denorm:*",
+							"ecm:currentLifeCycleState",
+							"ecm:name",
+							"ecm:primaryType",
+							"media_common:blobCsid"
+						]
+					},
+					"properties" : {
+						"all_field": {
+							"type": "text",
+							"analyzer": "fulltext"
+						},
+
+						"ecm:currentLifeCycleState": {
+							"type": "keyword"
+						},
+						"ecm:name": {
+							"type": "keyword"
+						},
+						"ecm:primaryType": {
+							"type": "text",
+							"analyzer" : "doctype_analyzer"
+						},
+
+						"collectionspace_core:createdAt": {
+							"type": "date",
+							"format": "date_time"
+						},
+						"collectionobjects_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						},
+
+						"collectionspace_denorm:title": {
+							"type": "keyword",
+							"normalizer": "sorting_normalizer"
+						},
+						"collectionspace_denorm:hasMedia": {
+							"type": "boolean"
+						},
+						"collectionspace_denorm:mediaAltText": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionspace_denorm:prodYears": {
+							"type": "integer"
+						},
+						"collectionspace_denorm:exhibition": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								},
+								"generalNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								},
+								"curatorialNote": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionspace_denorm:contentSubjectList": {
+							"type": "object",
+							"properties": {
+								"subject": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+
+						"collectionobjects_common:objectNumber": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:briefDescriptions": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:titleGroupList": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectNameList": {
+							"type": "object",
+							"properties": {
+								"objectName": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPersonGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPerson": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionOrganizationGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionOrganization": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPeopleGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPeople": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionDateGroupList": {
+							"type": "object",
+							"properties": {
+								"dateDisplayDate": {
+									"type": "text",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectProductionPlaceGroupList": {
+							"type": "object",
+							"properties": {
+								"objectProductionPlace": {
+									"type": "keyword",
+									"copy_to": "all_field",
+									"fields": {
+										"displayName": {
+											"type": "keyword",
+											"normalizer": "refname_displayname_normalizer"
+										}
+									}
+								}
+							}
+						},
+						"collectionobjects_common:materialGroupList": {
+							"type": "object",
+							"properties": {
+								"material": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:colors": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:responsibleDepartments": {
+							"type": "keyword",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentConcepts": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentDescription": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:contentEvents": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentOrganizations": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:contentPersons": {
+							"type": "keyword",
+							"copy_to": "all_field",
+							"fields": {
+								"displayName": {
+									"type": "keyword",
+									"normalizer": "refname_displayname_normalizer"
+								}
+							}
+						},
+						"collectionobjects_common:techniqueGroupList": {
+							"type": "object",
+							"properties": {
+								"technique": {
+									"type": "keyword",
+									"copy_to": "all_field"
+								}
+							}
+						},
+						"collectionobjects_common:objectHistoryNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:ownersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+						"collectionobjects_common:viewersContributionNote": {
+							"type": "text",
+							"copy_to": "all_field"
+						},
+
+						"media_common:blobCsid": {
+							"type": "keyword"
+						},
+						"media_common:publishToList": {
+							"type": "keyword",
+							"fields": {
+								"shortid": {
+									"type": "keyword",
+									"normalizer": "refname_shortid_normalizer"
+								}
+							}
+						}
+					}
+				}
+			</tenant:mapping>
+		</tenant:elasticSearchIndexConfig>
+	</tenant:tenantBinding>
 </tenant:TenantBindingConfig>


### PR DESCRIPTION
**What does this do?**

This adds Elasticsearch configuration to LHMC and LHMC-based tenants (breman, kennesaw, usopc, and westerville), to override the default Elasticsearch configuration. The LHMC configuration differs from the default in that it considers objectProductionPlace to be a refname, and indexes just the display name for use in faceted search.

This fix will be in the CSpace 8.0 release. This PR pulls it into 7.2 for hosted instances.

**Why are we doing this? (with JIRA link)**

This is needed to fix the public browser displaying/filtering on urns instead of human-readable names -- specifically for Westerville, which will likely be in production before 8.0 is released.

JIRA: https://collectionspace.atlassian.net/jira/software/c/projects/CB/issues/CB-29

